### PR TITLE
Changed build script output to a more UX friendly name

### DIFF
--- a/scripts/build.js
+++ b/scripts/build.js
@@ -195,6 +195,14 @@ if (Object.keys(packageJson.dependencies).length) {
 }
 
 // Create tgz of the build
+let tgzFile = `${manifestJson.name}-${manifestJson.version}`
+if(Boolean(argv['l'])) {
+	// -l flag, legacy behaviour creating pkg.tgz output
+	tgzFile = 'pkg'
+}
+tgzFile += '.tgz'
+console.log('Writing compressed package output to', tgzFile)
+
 await tar
 	.create(
 		{


### PR DESCRIPTION
changed default output of build script to ${package}-${version}.tgz . Added flag -l keeping the legacy behavior with file output pkg.tgz

So in module foo-bar , version 1.2.0 
`yarn package`
will output file foo-bar-1.2.0.tgz
 
`yarn package -l`
will output file pkg.tgz 
