### PR TITLE
Make the recommended*.json tsconfigs extend a common base and contain only the settings they disagree on

### DIFF
--- a/tsconfig/node22/recommended-esm.json
+++ b/tsconfig/node22/recommended-esm.json
@@ -1,26 +1,11 @@
 {
+	"extends": "../shared.json",
 	"compilerOptions": {
 		"module": "node20",
 		"target": "es2024",
-		"noImplicitAny": true,
 		"moduleResolution": "node16",
-		"sourceMap": true,
-		"declaration": false,
-		"importHelpers": false,
-		"listFiles": false,
-		"traceResolution": false,
-		"pretty": true,
-		"lib": ["es2024"],
-		"types": ["node"],
-		"strict": true,
-		"forceConsistentCasingInFileNames": true,
-		"noFallthroughCasesInSwitch": true,
-		"noImplicitReturns": true,
-		"noUnusedLocals": true,
-		"noUnusedParameters": true,
-		"skipLibCheck": true,
-		"allowSyntheticDefaultImports": true,
-		"esModuleInterop": true
-	},
-	"compileOnSave": false
+		"lib": [
+			"es2024"
+		]
+	}
 }

--- a/tsconfig/node22/recommended.json
+++ b/tsconfig/node22/recommended.json
@@ -1,26 +1,11 @@
 {
+	"extends": "../shared.json",
 	"compilerOptions": {
 		"module": "commonjs",
 		"target": "es2022",
-		"noImplicitAny": true,
 		"moduleResolution": "node",
-		"sourceMap": true,
-		"declaration": false,
-		"importHelpers": false,
-		"listFiles": false,
-		"traceResolution": false,
-		"pretty": true,
-		"lib": ["es2023"],
-		"types": ["node"],
-		"strict": true,
-		"forceConsistentCasingInFileNames": true,
-		"noFallthroughCasesInSwitch": true,
-		"noImplicitReturns": true,
-		"noUnusedLocals": true,
-		"noUnusedParameters": true,
-		"skipLibCheck": true,
-		"allowSyntheticDefaultImports": true,
-		"esModuleInterop": true
-	},
-	"compileOnSave": false
+		"lib": [
+			"es2023"
+		]
+	}
 }

--- a/tsconfig/shared.json
+++ b/tsconfig/shared.json
@@ -1,0 +1,24 @@
+{
+    "compilerOptions": {
+        "noImplicitAny": true,
+        "sourceMap": true,
+        "declaration": false,
+        "importHelpers": false,
+        "listFiles": false,
+        "traceResolution": false,
+        "pretty": true,
+        "types": [
+            "node"
+        ],
+        "strict": true,
+        "forceConsistentCasingInFileNames": true,
+        "noFallthroughCasesInSwitch": true,
+        "noImplicitReturns": true,
+        "noUnusedLocals": true,
+        "noUnusedParameters": true,
+        "skipLibCheck": true,
+        "allowSyntheticDefaultImports": true,
+        "esModuleInterop": true
+    },
+    "compileOnSave": false
+}


### PR DESCRIPTION
Helps with readability in understanding exactly what differs between them.